### PR TITLE
Fixing an invalid metric ValueType

### DIFF
--- a/src/model/sensor.rs
+++ b/src/model/sensor.rs
@@ -85,7 +85,7 @@ pub enum ValueUnit {
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize, EnumIter)]
 pub enum ValueType {
-    #[serde(rename = "boolean")]
+    #[serde(rename = "bool")]
     Boolean,
 
     #[serde(rename = "double")]


### PR DESCRIPTION
[Fixing an invalid metric ValueType, which caused the following bug 'Given metricType boolean is not valid. Supported types:\n[\nbool\nstring\ndouble\ninteger\n]'.